### PR TITLE
update team registrations index page

### DIFF
--- a/app/views/team_registrations/index.html.erb
+++ b/app/views/team_registrations/index.html.erb
@@ -7,7 +7,7 @@
 <% else %>
   You do not have any team registrations. Would you like to <%= link_to 'register one', new_team_registration_path %>?
 <% end  %>
-<% if @user.complete_team_registrations.size > 0 %>
+<% if @user.team_registrations.size > 0 %>
   <b>My Team Registrations</b>
   <div class="table-responsive"> 
     <table class="table table-striped">


### PR DESCRIPTION
update user's team registrations page to actually show team registrations regardless of complete status. this is a hold out from years past where completeness was determined by a third party system.